### PR TITLE
[IMP] nfc, reader, tag: Comply with linter rules about white characters.

### DIFF
--- a/nfc.py
+++ b/nfc.py
@@ -7,6 +7,7 @@ from smartcard.Exceptions import CardRequestException
 from tag import NTAG215
 from reader import Reader, ACR122U
 
+
 class Contact:
     name: str
     phone: str
@@ -70,7 +71,8 @@ END:VCARD"""
         email = input("Enter email: ")
         company = input("Enter company: ")
         return Contact(name, phone, email, company)
-        
+
+
 class VCardAPI:
     verbose: bool
     reader: Reader
@@ -107,6 +109,7 @@ class VCardAPI:
         self.reader.wait_for_card(self.reader.write_card, "text/x-vcard", vcard.encode("utf-8"))
         self._log("Contact written")
 
+
 def _get_args():
     parser = ArgumentParser()
     parser.add_argument("-w", "--write", required=False, action="store_true")
@@ -114,6 +117,7 @@ def _get_args():
     parser.add_argument("-t", "--timeout", required=False, type=int, default=10, help="The maximum time in seconds to wait for a card")
 
     return parser.parse_args()
+
 
 def _main():
     args = _get_args()
@@ -125,6 +129,7 @@ def _main():
     else:
         contact = reader.read_contact()
         print(contact)
+
 
 if __name__ == "__main__":
     _main()

--- a/tag.py
+++ b/tag.py
@@ -1,6 +1,7 @@
 from smartcard.CardType import ATRCardType, CardType
 from typing import Final
 
+
 class Tag:
     atr: CardType
     bytes_per_page: int
@@ -13,5 +14,6 @@ class Tag:
         self.memory_page_start = memory_page_start
         self.memory_page_max = memory_page_max
 
-# The values comes from: https://www.nxp.com/docs/en/data-sheet/NTAG213_215_216.pdf 
+
+# The values comes from: https://www.nxp.com/docs/en/data-sheet/NTAG213_215_216.pdf
 NTAG215: Final[Tag] = Tag([59, 143, 128, 1, 128, 79, 12, 160, 0, 0, 3, 6, 3, 0, 3, 0, 0, 0, 0, 104], 4, 4, 126)


### PR DESCRIPTION
Add double spaces where the linter ask for and remove trailing white spaces.